### PR TITLE
Fix _replicate

### DIFF
--- a/swagger/lite.yaml
+++ b/swagger/lite.yaml
@@ -40,9 +40,12 @@ paths:
     $ref: ./paths/_all_dbs.yaml
   /_replicate:
     post:
-      description: This request starts or cancels a database replication operation.
+      description: |
+        This request starts or cancels a database replication operation.
+        
+        You can cancel continuous replications by adding the cancel field to the JSON request object and setting the value to true. Note that the structure of the request must be identical to the original for the cancellation request to be honoured. For example, if you requested continuous replication, the cancellation request must also contain the continuous field.
       parameters:
-        - $ref: '#/parameters/replication'
+        - $ref: '#/parameters/replication_lite'
       responses:
         200:
           description: 200 OK

--- a/swagger/parameters/index.yaml
+++ b/swagger/parameters/index.yaml
@@ -120,9 +120,37 @@ open_revs:
   type: array
   items:
     type: string
-replication:
+replication_lite:
   in: body
-  name: replicate
+  name: body
+  description: The request message body is a JSON document that contains the following objects.
+  schema:
+    type: object
+    properties:
+      create_target:
+        type: boolean
+        description: Indicates whether to create the target database
+      source:
+        type: string
+        description: Identifies the database to copy revisions from. Can be a string containing a local database name or a remote database URL, or an object whose url property contains the database name or URL. Also an object can contain headers property that contains custom header values such as a cookie.
+      target:
+        type: string
+        description: Identifies the database to copy revisions to. Same format and interpretation as source.
+      continuous:
+        type: boolean
+        description: Specifies whether the replication should be in continuous mode.
+      filter:
+        type: string
+        description: Indicates that the documents should be filtered using the specified filter function name. A common value used when replicating from Sync Gateway is sync_gateway/bychannel to limit the pull replication to a set of channels.
+      query_params:
+        type: object
+        description: A set of key/value pairs to use in the querystring of the replication. For example, the channels field can be used to pull from a set of channels (in this particular case, the filter key must be set for the channels field to work as expected).
+      cancel:
+        type: boolean
+        description: Indicates that a running replication task should be cancelled, the running task is identified by passing its replication_id or by passing the original source and target values.
+replication_sg:
+  in: body
+  name: body
   description: The request message body is a JSON document that contains the following objects.
   schema:
     type: object


### PR DESCRIPTION
There is no replication_id parameter in the request body of _replicate on CBL

@snej How is a replication stopped via the REST API? What else should be sent with the `cancel: true` property?

Connects #372