### PR TITLE
POST /{db}/_bulk_get forbidden response definition

### DIFF
--- a/swagger/paths/sg/common.yaml
+++ b/swagger/paths/sg/common.yaml
@@ -36,6 +36,20 @@
               type: array
               items:
                 $ref: '#/definitions/Success'
+      301:
+        description: Request failed with a forbidden error. This usually happens because the user requesting that document doesn't have access to it. Access to documents is granted to users through channels.
+        schema:
+          type: object
+          properties:
+            _id:
+              type: string
+              description: The document ID that was requested
+            _removed:
+              type: boolean
+              default: true
+            _rev:
+              type: string
+              description: The revision number that was requested
 /{db}/_local/{local_doc}:
   parameters:
     - $ref: '#/parameters/db'


### PR DESCRIPTION
Following from https://github.com/couchbase/sync_gateway/issues/2212#event-926293635, I couldn't find a way to nicely display the difference in the response model depending on whether the "rev" is sent in the request body.

@tleyden can you review this PR? (in particular whether the description of the response definition makes sense)