### PR TITLE
Fixed typo for installing on MacOSX. Note, there is an error with the…

### DIFF
--- a/md-docs/_1x/installation/sync-gateway.md
+++ b/md-docs/_1x/installation/sync-gateway.md
@@ -128,12 +128,14 @@ The config file and logs are located in ``.
 Install sync_gateway by unpacking the tar.gz installer.
 
 ```bash
-sudo tar --zxvf {{ site.sg_package_name }}.tar.gz --directory /opt
+sudo tar -zxvf {{ site.sg_package_name }}.tar.gz --directory /opt
 ```
 
 Create the sync_gateway service.
 
 ```bash
+$ sudo mkdir /Users/sync_gateway
+
 $ cd /opt/couchbase-sync-gateway/service
 
 $ sudo ./sync_gateway_service_install.sh


### PR DESCRIPTION
The installation should be:

`sudo tar -zxvf {{ site.sg_package_name }}.tar.gz --directory /opt
`

Also added line to create directory **sudo mkdir /Users/sync_gateway** as its needed. 