### PR TITLE
Add missing items property to role property all_channels object description

### DIFF
--- a/swagger/paths/sg/admin.yaml
+++ b/swagger/paths/sg/admin.yaml
@@ -405,6 +405,8 @@
             all_channels:
               type: array
               description: All the channels that this role has access to.
+              items:
+                type: string
   put:
     tags:
       - role


### PR DESCRIPTION
The role object property all_channels is missing the items property. This prevent swagger-codegen-cli to generate the javascript client library.