### PR TITLE
Add https to available schemes in public spec

### DIFF
--- a/swagger/public.yaml
+++ b/swagger/public.yaml
@@ -11,6 +11,7 @@ host: localhost:4984
 # array of all schemes that your API supports
 schemes:
   - http
+  - https
 # will be prefixed to all paths
 basePath: /
 produces:


### PR DESCRIPTION
If a tool like swagger-client is trying to auto-detect what scheme to use either from the spec url used in the constructor or from the browser window, it will fail to use https without https available in the schemes of the spec.