### PR TITLE
Update definitions

### DIFF
--- a/swagger/14/definitions/common.yaml
+++ b/swagger/14/definitions/common.yaml
@@ -221,12 +221,24 @@ User:
       items:
         type: string
         description: Role name
+    all_channels:
+      type: array
+      description: Array of channel names the user is given access to
+      items:
+        type: string
+        description: Channel name
     email:
       type: string
       description: Email of the user that will be created.
     disabled:
       type: boolean
       description: Boolean property to disable this user. The user will not be able to login if this property is set to true.
+    roles:
+      type: array
+      description: Array of role names the user is given access to
+      items:
+        type: string
+        description: Role name
 ChangesFeedRow:
   type: object
   properties:

--- a/swagger/14/parameters/common.yaml
+++ b/swagger/14/parameters/common.yaml
@@ -35,7 +35,8 @@ body:
   in: body
   description: The request body
   schema:
-    type: object
+    type: string
+    format: binary
 bulkget:
   in: body
   name: BulkGetBody
@@ -63,6 +64,11 @@ channels_list:
   description: A comma-separated list of channel names. The response will be filtered to only documents in these channels. (This parameter must be used with the sync_gateway/bychannel filter parameter; see below.)
   type: string
   required: false
+content_type:
+  in: header
+  name: Content-Type
+  description: Attachment Content-Type
+  type: string
 db:
   name: db
   in: path

--- a/swagger/14/paths/common.yaml
+++ b/swagger/14/paths/common.yaml
@@ -14,6 +14,9 @@
     responses:
       200:
         description: The message body contains the attachment, in the format specified in the Content-Type header.
+        schema:
+          type: string
+          format: binary
       304:
         description: Not Modified, the attachment wasn't modified if ETag equals the If-None-Match header
       404:
@@ -31,6 +34,7 @@
     parameters:
       - $ref: '#/parameters/rev'
       - $ref: '#/parameters/body'
+      - $ref: '#/parameters/content_type'
     responses:
       200:
         description: Operation completed successfully

--- a/swagger/14/paths/sg/common.yaml
+++ b/swagger/14/paths/sg/common.yaml
@@ -149,7 +149,7 @@
       200:
         description: The message body contains the following objects in a JSON document.
         schema:
-          $ref: '#/definitions/Success'
+          type: object
   put:
     tags:
       - document

--- a/swagger/14/public.yaml
+++ b/swagger/14/public.yaml
@@ -12,6 +12,18 @@ host: localhost:4984
 schemes:
   - http
   - https
+# Security schemes available
+securityDefinitions:
+  basicAuth:
+    type: basic
+    description: HTTP Basic Authentication
+  apiKey:
+    name: Cookie
+    type: apiKey
+    in: header
+# Security schemes applied for the API as a whole
+security:
+  - apiKey: []
 # will be prefixed to all paths
 basePath: /
 produces:


### PR DESCRIPTION
This PR contains

- missing fields in the user definition to comply with the sync gateway [documentation](https://developer.couchbase.com/documentation/mobile/current/guides/sync-gateway/authorizing-users/index.html).
- allows to push and retrieve raw data for attachments as the 'object' definition only allows JSON format and to precise the content-type thanks to the Content-Type header parameter.
- security access description for HTTP Basic authentication and Cookie-based sessions.
- allows to return object from `GET /{db}/{doc}` instead of 'Success'. A better definition for the response schema should be as follow using the [version 3.0.0 of the OAI specification which eases to declare additional properties](https://github.com/OAI/OpenAPI-Specification/blob/3.0.0-rc0/versions/3.0.md#schema-object) but it is not yet supported by swagger.
```
Document:
  type: object
  properties:
    _id:
      type: string
      description: Document identifier
    _rev:
      type: string
      description: Revision identifier
    additionalProperties: true
```

**Sync gateway version used for the tests:** Couchbase Sync Gateway/1.4.0(2;9e18d3e)