### PR TITLE
Do not dereference internal $ref pointers.

### DIFF
--- a/swagger/gulpfile.js
+++ b/swagger/gulpfile.js
@@ -5,6 +5,14 @@ var gulp = require('gulp')
   , argv = require('yargs').argv
   , version = argv.version + '/';
 
+var swaggerOptions = {
+  parser: {
+    $refs: {
+      internal: false
+    }
+  }
+};
+
 /**
  * Concat the parameters into parameters/index.yaml
  */
@@ -62,19 +70,19 @@ gulp.task('paths-sg-admin', function () {
 
 gulp.task('public', ['params-sg', 'definitions-sg', 'paths-sg-public'], function () {
   return gulp.src(version + 'public.yaml')
-    .pipe(swagger('sync-gateway-public.json'))
+    .pipe(swagger('sync-gateway-public.json', swaggerOptions))
     .pipe(gulp.dest('tmp'))
 });
 
 gulp.task('admin', ['params-sg', 'definitions-sg', 'paths-sg-admin'], function () {
   return gulp.src(version + 'admin.yaml')
-    .pipe(swagger('sync-gateway-admin.json'))
+    .pipe(swagger('sync-gateway-admin.json', swaggerOptions))
     .pipe(gulp.dest('tmp'))
 });
 
 gulp.task('cbl', ['params-cbl', 'definitions-cbl', 'paths-cbl'], function () {
   return gulp.src(version + 'cbl.yaml')
-    .pipe(swagger('couchbase-lite.json'))
+    .pipe(swagger('couchbase-lite.json', swaggerOptions))
     // run the swagger js code
     .pipe(gulp.dest('tmp'))
 });

--- a/swagger/package.json
+++ b/swagger/package.json
@@ -9,10 +9,10 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "gulp-swagger": "0.0.10",
+    "gulp-swagger": "^1.0.1",
     "js-yaml": "^3.6.1",
     "json-refs": "^2.1.6",
-    "swagger-client": "^2.1.15",
+    "swagger-client": "^3.0.3",
     "yaml-js": "^0.1.3"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR updates the [gulp-swagger](https://github.com/gersongoulart/gulp-swagger) dependency to be able to configure the underlying [SwaggerParser](https://github.com/BigstickCarpet/swagger-parser) in order to not dereference internal $ref pointers as described [here](https://github.com/BigstickCarpet/swagger-parser/blob/master/docs/options.md) in the documentation under the `$refs.internal` property.

This avoids the creation of unnecessary Inline objects in the final swagger specs.