### PR TITLE
Carthage install : Add import

### DIFF
--- a/md-docs/_1x/installation/ios.md
+++ b/md-docs/_1x/installation/ios.md
@@ -97,7 +97,16 @@ Create a new Xcode project and install Couchbase Lite by following one of the me
 
 <img src="../img/xcode-installation.png" class=center-image />
 
-Open **ViewController.swift** in Xcode and add the following in the `viewDidLoad` method.
+
+Open **ViewController.swift** in Xcode.
+
+If you installed through Carthage, append 
+```swift
+import CouchbaseLite
+```
+in your import section
+
+Then, add the following in the `viewDidLoad` method.
 
 ```swift
 // Create a manager


### PR DESCRIPTION
If you install through Carthage, you should append in your import section
```swift
import CouchbaseLite
```