### PR TITLE
Update input and output schema for _revs_diff

### DIFF
--- a/swagger/1.3/sync-gateway-admin.yaml
+++ b/swagger/1.3/sync-gateway-admin.yaml
@@ -1047,6 +1047,8 @@ paths:
               properties:
                 a_doc_id:
                   type: array
+                  items:
+                    type: string
                   description: An array of revision IDs for that document.
         responses:
           200:
@@ -1059,6 +1061,8 @@ paths:
                   properties:
                     missing:
                       type: array
+                      items:
+                        type: string
                       description: A list of revision IDs for that document (the ones that are not stored in the database).
   /_config:
     get:

--- a/swagger/1.3/sync-gateway-admin.yaml
+++ b/swagger/1.3/sync-gateway-admin.yaml
@@ -1033,37 +1033,37 @@ paths:
         401:
           description: Authentication failed.  Unable to refresh token.
   /{db}/_revs_diff:
+    parameters:
+      - $ref: '#/parameters/db'
+    post:
+      tags:
+        - database
+      summary: Used by the replicator
+      description: Given a set of document/revision IDs, returns the subset of those that do not correspond to revisions stored in the database.
       parameters:
-        - $ref: '#/parameters/db'
-      post:
-        summary: Used by the replicator
-        description: Given a set of document/revision IDs, returns the subset of those that do not correspond to revisions stored in the database.
-        parameters:
-          - in: body
-            name: body
-            description: Request body
-            schema:
+        - in: body
+          name: body
+          description: Request body
+          schema:
+            type: object
+            additionalProperties:
+              type: array
+              items:
+                type: string
+              description: An array of revision IDs for that document.
+      responses:
+        200:
+          description: The request was successful
+          schema:
+            type: object
+            additionalProperties:
               type: object
               properties:
-                a_doc_id:
+                missing:
                   type: array
                   items:
                     type: string
-                  description: An array of revision IDs for that document.
-        responses:
-          200:
-            description: The request was successful
-            schema:
-              type: object
-              properties:
-                a_doc_id:
-                  type: object
-                  properties:
-                    missing:
-                      type: array
-                      items:
-                        type: string
-                      description: A list of revision IDs for that document (the ones that are not stored in the database).
+                  description: A list of revision IDs for that document (the ones that are not stored in the database).
   /_config:
     get:
       tags:

--- a/swagger/1.3/sync-gateway-public.yaml
+++ b/swagger/1.3/sync-gateway-public.yaml
@@ -1035,37 +1035,37 @@ paths:
         401:
           description: Authentication failed.  Unable to refresh token.
   /{db}/_revs_diff:
+    parameters:
+      - $ref: '#/parameters/db'
+    post:
+      tags:
+        - database
+      summary: Used by the replicator
+      description: Given a set of document/revision IDs, returns the subset of those that do not correspond to revisions stored in the database.
       parameters:
-        - $ref: '#/parameters/db'
-      post:
-        summary: Used by the replicator
-        description: Given a set of document/revision IDs, returns the subset of those that do not correspond to revisions stored in the database.
-        parameters:
-          - in: body
-            name: body
-            description: Request body
-            schema:
+        - in: body
+          name: body
+          description: Request body
+          schema:
+            type: object
+            additionalProperties:
+              type: array
+              items:
+                type: string
+              description: An array of revision IDs for that document.
+      responses:
+        200:
+          description: The request was successful
+          schema:
+            type: object
+            additionalProperties:
               type: object
               properties:
-                a_doc_id:
+                missing:
                   type: array
                   items:
                     type: string
-                  description: An array of revision IDs for that document.
-        responses:
-          200:
-            description: The request was successful
-            schema:
-              type: object
-              properties:
-                a_doc_id:
-                  type: object
-                  properties:
-                    missing:
-                      type: array
-                      items:
-                        type: string
-                      description: A list of revision IDs for that document (the ones that are not stored in the database).
+                  description: A list of revision IDs for that document (the ones that are not stored in the database).
   /{db}/:
     parameters:
       - $ref: '#/parameters/db'

--- a/swagger/1.3/sync-gateway-public.yaml
+++ b/swagger/1.3/sync-gateway-public.yaml
@@ -1049,6 +1049,8 @@ paths:
               properties:
                 a_doc_id:
                   type: array
+                  items:
+                    type: string
                   description: An array of revision IDs for that document.
         responses:
           200:
@@ -1061,6 +1063,8 @@ paths:
                   properties:
                     missing:
                       type: array
+                      items:
+                        type: string
                       description: A list of revision IDs for that document (the ones that are not stored in the database).
   /{db}/:
     parameters:

--- a/swagger/1.4/sync-gateway-admin.yaml
+++ b/swagger/1.4/sync-gateway-admin.yaml
@@ -1047,6 +1047,8 @@ paths:
               properties:
                 a_doc_id:
                   type: array
+                  items:
+                    type: string
                   description: An array of revision IDs for that document.
         responses:
           200:
@@ -1059,6 +1061,8 @@ paths:
                   properties:
                     missing:
                       type: array
+                      items:
+                        type: string
                       description: A list of revision IDs for that document (the ones that are not stored in the database).
   /_config:
     get:

--- a/swagger/1.4/sync-gateway-admin.yaml
+++ b/swagger/1.4/sync-gateway-admin.yaml
@@ -1033,37 +1033,37 @@ paths:
         401:
           description: Authentication failed.  Unable to refresh token.
   /{db}/_revs_diff:
+    parameters:
+      - $ref: '#/parameters/db'
+    post:
+      tags:
+        - database
+      summary: Used by the replicator
+      description: Given a set of document/revision IDs, returns the subset of those that do not correspond to revisions stored in the database.
       parameters:
-        - $ref: '#/parameters/db'
-      post:
-        summary: Used by the replicator
-        description: Given a set of document/revision IDs, returns the subset of those that do not correspond to revisions stored in the database.
-        parameters:
-          - in: body
-            name: body
-            description: Request body
-            schema:
+        - in: body
+          name: body
+          description: Request body
+          schema:
+            type: object
+            additionalProperties:
+              type: array
+              items:
+                type: string
+              description: An array of revision IDs for that document.
+      responses:
+        200:
+          description: The request was successful
+          schema:
+            type: object
+            additionalProperties:
               type: object
               properties:
-                a_doc_id:
+                missing:
                   type: array
                   items:
                     type: string
-                  description: An array of revision IDs for that document.
-        responses:
-          200:
-            description: The request was successful
-            schema:
-              type: object
-              properties:
-                a_doc_id:
-                  type: object
-                  properties:
-                    missing:
-                      type: array
-                      items:
-                        type: string
-                      description: A list of revision IDs for that document (the ones that are not stored in the database).
+                  description: A list of revision IDs for that document (the ones that are not stored in the database).
   /_config:
     get:
       tags:

--- a/swagger/1.4/sync-gateway-public.yaml
+++ b/swagger/1.4/sync-gateway-public.yaml
@@ -1035,37 +1035,37 @@ paths:
         401:
           description: Authentication failed.  Unable to refresh token.
   /{db}/_revs_diff:
+    parameters:
+      - $ref: '#/parameters/db'
+    post:
+      tags:
+        - database
+      summary: Used by the replicator
+      description: Given a set of document/revision IDs, returns the subset of those that do not correspond to revisions stored in the database.
       parameters:
-        - $ref: '#/parameters/db'
-      post:
-        summary: Used by the replicator
-        description: Given a set of document/revision IDs, returns the subset of those that do not correspond to revisions stored in the database.
-        parameters:
-          - in: body
-            name: body
-            description: Request body
-            schema:
+        - in: body
+          name: body
+          description: Request body
+          schema:
+            type: object
+            additionalProperties:
+              type: array
+              items:
+                type: string
+              description: An array of revision IDs for that document.
+      responses:
+        200:
+          description: The request was successful
+          schema:
+            type: object
+            additionalProperties:
               type: object
               properties:
-                a_doc_id:
+                missing:
                   type: array
                   items:
                     type: string
-                  description: An array of revision IDs for that document.
-        responses:
-          200:
-            description: The request was successful
-            schema:
-              type: object
-              properties:
-                a_doc_id:
-                  type: object
-                  properties:
-                    missing:
-                      type: array
-                      items:
-                        type: string
-                      description: A list of revision IDs for that document (the ones that are not stored in the database).
+                  description: A list of revision IDs for that document (the ones that are not stored in the database).
   /{db}/:
     parameters:
       - $ref: '#/parameters/db'

--- a/swagger/1.4/sync-gateway-public.yaml
+++ b/swagger/1.4/sync-gateway-public.yaml
@@ -1049,6 +1049,8 @@ paths:
               properties:
                 a_doc_id:
                   type: array
+                  items:
+                    type: string
                   description: An array of revision IDs for that document.
         responses:
           200:
@@ -1061,6 +1063,8 @@ paths:
                   properties:
                     missing:
                       type: array
+                      items:
+                        type: string
                       description: A list of revision IDs for that document (the ones that are not stored in the database).
   /{db}/:
     parameters:

--- a/swagger/1.5/sync-gateway-admin.yaml
+++ b/swagger/1.5/sync-gateway-admin.yaml
@@ -1044,9 +1044,12 @@ paths:
             description: Request body
             schema:
               type: object
+              additionalProperties: true
               properties:
                 a_doc_id:
                   type: array
+                  items:
+                    type: string
                   description: An array of revision IDs for that document.
         responses:
           200:
@@ -1059,6 +1062,8 @@ paths:
                   properties:
                     missing:
                       type: array
+                      items:
+                        type: string
                       description: A list of revision IDs for that document (the ones that are not stored in the database).
   /_config:
     get:

--- a/swagger/1.5/sync-gateway-admin.yaml
+++ b/swagger/1.5/sync-gateway-admin.yaml
@@ -1044,7 +1044,6 @@ paths:
             description: Request body
             schema:
               type: object
-              additionalProperties: true
               properties:
                 a_doc_id:
                   type: array

--- a/swagger/1.5/sync-gateway-admin.yaml
+++ b/swagger/1.5/sync-gateway-admin.yaml
@@ -1033,37 +1033,37 @@ paths:
         401:
           description: Authentication failed.  Unable to refresh token.
   /{db}/_revs_diff:
+    parameters:
+      - $ref: '#/parameters/db'
+    post:
+      tags:
+        - database
+      summary: Used by the replicator
+      description: Given a set of document/revision IDs, returns the subset of those that do not correspond to revisions stored in the database.
       parameters:
-        - $ref: '#/parameters/db'
-      post:
-        summary: Used by the replicator
-        description: Given a set of document/revision IDs, returns the subset of those that do not correspond to revisions stored in the database.
-        parameters:
-          - in: body
-            name: body
-            description: Request body
-            schema:
+        - in: body
+          name: body
+          description: Request body
+          schema:
+            type: object
+            additionalProperties:
+              type: array
+              items:
+                type: string
+              description: An array of revision IDs for that document.
+      responses:
+        200:
+          description: The request was successful
+          schema:
+            type: object
+            additionalProperties:
               type: object
               properties:
-                a_doc_id:
+                missing:
                   type: array
                   items:
                     type: string
-                  description: An array of revision IDs for that document.
-        responses:
-          200:
-            description: The request was successful
-            schema:
-              type: object
-              properties:
-                a_doc_id:
-                  type: object
-                  properties:
-                    missing:
-                      type: array
-                      items:
-                        type: string
-                      description: A list of revision IDs for that document (the ones that are not stored in the database).
+                  description: A list of revision IDs for that document (the ones that are not stored in the database).
   /_config:
     get:
       tags:

--- a/swagger/1.5/sync-gateway-public.yaml
+++ b/swagger/1.5/sync-gateway-public.yaml
@@ -1035,37 +1035,37 @@ paths:
         401:
           description: Authentication failed.  Unable to refresh token.
   /{db}/_revs_diff:
+    parameters:
+      - $ref: '#/parameters/db'
+    post:
+      tags:
+        - database
+      summary: Used by the replicator
+      description: Given a set of document/revision IDs, returns the subset of those that do not correspond to revisions stored in the database.
       parameters:
-        - $ref: '#/parameters/db'
-      post:
-        summary: Used by the replicator
-        description: Given a set of document/revision IDs, returns the subset of those that do not correspond to revisions stored in the database.
-        parameters:
-          - in: body
-            name: body
-            description: Request body
-            schema:
+        - in: body
+          name: body
+          description: Request body
+          schema:
+            type: object
+            additionalProperties:
+              type: array
+              items:
+                type: string
+              description: An array of revision IDs for that document.
+      responses:
+        200:
+          description: The request was successful
+          schema:
+            type: object
+            additionalProperties:
               type: object
               properties:
-                a_doc_id:
+                missing:
                   type: array
                   items:
                     type: string
-                  description: An array of revision IDs for that document.
-        responses:
-          200:
-            description: The request was successful
-            schema:
-              type: object
-              properties:
-                a_doc_id:
-                  type: object
-                  properties:
-                    missing:
-                      type: array
-                      items:
-                        type: string
-                      description: A list of revision IDs for that document (the ones that are not stored in the database).
+                  description: A list of revision IDs for that document (the ones that are not stored in the database).
   /{db}/:
     parameters:
       - $ref: '#/parameters/db'

--- a/swagger/1.5/sync-gateway-public.yaml
+++ b/swagger/1.5/sync-gateway-public.yaml
@@ -1049,6 +1049,8 @@ paths:
               properties:
                 a_doc_id:
                   type: array
+                  items:
+                    type: string
                   description: An array of revision IDs for that document.
         responses:
           200:
@@ -1061,6 +1063,8 @@ paths:
                   properties:
                     missing:
                       type: array
+                      items:
+                        type: string
                       description: A list of revision IDs for that document (the ones that are not stored in the database).
   /{db}/:
     parameters:


### PR DESCRIPTION
Hi,

I replaced the `a_doc_id` property by using the more generic `additionalProperty` property to add maps to schema objects as described in the [Swagger Schema Object properties](https://swagger.io/specification/#properties-99) documentation.

Regards,

Julien