### PR TITLE
update fts docs search term.

### DIFF
--- a/md-docs/_20/couchbase-lite/swift.md
+++ b/md-docs/_20/couchbase-lite/swift.md
@@ -624,6 +624,14 @@ do {
 
 In the example above, the pattern to  match is a word, the full-text search query matches all documents that contain the word 'buy' in the value of the `doc.name` property.
 
+The pattern to match can also be in the following forms:
+
+- **prefix queries:** the query expression used to search for a term prefix is the prefix itself with a '*' character appended to it. For example, `"'lin*'"`.
+- **phrase queries:** a phrase query is a query that retrieves all documents that contain a nominated set of terms or term prefixes in a specified order with no intervening tokens. Phrase queries are specified by enclosing a space separated sequence of terms or term prefixes in double quotes ("). For example `"'"linux applications"'"`.
+- **NEAR queries:** A NEAR query is a query that returns documents that contain a two or more nominated terms or phrases within a specified proximity of each other (by default with 10 or less intervening terms). A NEAR query is specified by putting the keyword "NEAR" between two phrase, token or token prefix queries. To specify a proximity other than the default, an operator of the form "NEAR/<N>" may be used, where <N> is the maximum number of intervening terms allowed. For example `"'database NEAR/2 "replication"'"`.
+
+### Ordering results
+
 It's very common to sort full-text results in descending order of relevance. This can be a very difficult heuristic to define, but Couchbase Lite comes with a fairly simple ranking function you can use. In the `OrderBy` array, use a string of the form `Rank(X)`, where `X` is the property or expression being searched, to represent the ranking of the result.
 
 ## Replication


### PR DESCRIPTION
Updating docs to explain the search term syntax (from https://www.sqlite.org/fts3.html#full_text_index_queries)

@snej could you take a look when you get a chance? Does the Couchbase Lite search term syntax follow all the formats supported by SQLite?